### PR TITLE
refactors to use `Testcontainers` for better test isolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.mockk:mockk:1.13.11")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
 }
 
 kotlin {

--- a/src/test/kotlin/com/perquizz/perquizz/integration/IntegrationTestSummary.kt
+++ b/src/test/kotlin/com/perquizz/perquizz/integration/IntegrationTestSummary.kt
@@ -1,0 +1,29 @@
+package com.perquizz.perquizz.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.test.web.servlet.MockMvc
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class IntegrationTestSummary {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var mapper: ObjectMapper
+
+    companion object {
+        @Container
+        @ServiceConnection
+        @JvmStatic
+        val container = PostgreSQLContainer("postgres:16.0-alpine3.18")
+    }
+}

--- a/src/test/kotlin/com/perquizz/perquizz/integration/MigrationControllerTest.kt
+++ b/src/test/kotlin/com/perquizz/perquizz/integration/MigrationControllerTest.kt
@@ -7,24 +7,16 @@ import org.hamcrest.Matchers.stringContainsInOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ActiveProfiles("db-test")
-@SpringBootTest
-@AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class MigrationControllerTest {
-    @Autowired
-    lateinit var mockMvc: MockMvc
-
+class MigrationControllerTest : IntegrationTestSummary() {
     @Autowired
     lateinit var flyway: Flyway
 

--- a/src/test/kotlin/com/perquizz/perquizz/integration/StatusControllerTest.kt
+++ b/src/test/kotlin/com/perquizz/perquizz/integration/StatusControllerTest.kt
@@ -2,20 +2,11 @@ package com.perquizz.perquizz.integration
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@SpringBootTest
-@AutoConfigureMockMvc
-class StatusControllerTest {
-    @Autowired
-    lateinit var mockMvc: MockMvc
-
+class StatusControllerTest : IntegrationTestSummary() {
     @Test
     fun `should return status 200`() {
         val result = mockMvc.perform(get("/api/v1/status"))


### PR DESCRIPTION
On progressing with feature testing, it started to become harder to isolate tests when running them against the local database inside the docker image.
For this reason, the author proposes the addition of the `Testcontainers` dependency, since it is a library responsable for configuring, serving, and cleaning databases with docker images, specifically for using in tests, offering a more robust solution, with less configuration, for achieving the desired result that today is manually implemented in the source code.

For code reusability and sharing the container configuration between the integration tests, it was created a new class `IntegrationTestSummary`.

Simply extending the class is enough to make a test class run using the `Testcontainer` configured database instead of the local database.
